### PR TITLE
DYN-0003 Remove Challenger 2 and reaper drone from the vehicle manager

### DIFF
--- a/Scripts/VehicleSpawn/Menu/armour.sqf
+++ b/Scripts/VehicleSpawn/Menu/armour.sqf
@@ -1,7 +1,6 @@
 removeAllActions VM;
 VM addAction ["<t color='#ff1111'>Vehicle Manager</t>", hint ""]; 
 VM addAction ["==================", hint ""];
-VM addAction ["Spawn Challenger 2 MBT", "Scripts\VehicleSpawn\armour.sqf", [["CHALL2"]]];
 VM addAction ["Spawn Warrior", "Scripts\VehicleSpawn\armour.sqf", [["WARRIOR"]]];
 VM addAction ["Spawn Bulldog GPMG", "Scripts\VehicleSpawn\armour.sqf", [["BULLDOGGPMG"]]];
 VM addAction ["Spawn Bulldog HMG", "Scripts\VehicleSpawn\armour.sqf", [["BULLDOGHMG"]]];

--- a/Scripts/VehicleSpawn/armour.sqf
+++ b/Scripts/VehicleSpawn/armour.sqf
@@ -1,7 +1,7 @@
 _LO = ((_this select 3) select 0) select 0;
 
-//classnames
-_challenger2 = "CUP_B_Challenger2_2CW_BAF";
+// classnames
+// _challenger2 = "CUP_B_Challenger2_2CW_BAF";
 _warrior = "UK3CB_MDF_B_Warrior_Cage_Camo";
 _bulldogGPMG = "UK3CB_BAF_FV432_Mk3_GPMG_Green_MTP";
 _bulldogHMG = "UK3CB_BAF_FV432_Mk3_RWS_Green_MTP";
@@ -22,11 +22,6 @@ spawnARMOUR = {
 
 
 switch (_LO) do {
-	case "CHALL2" :
-	{
-		[ArmourSpawn, _challenger2] call spawnARMOUR;
-	};
-
 	case "WARRIOR":
 	{
 		[ArmourSpawn, _warrior] call spawnARMOUR;

--- a/Scripts/VehicleSpawn/aviation.sqf
+++ b/Scripts/VehicleSpawn/aviation.sqf
@@ -1,10 +1,10 @@
 _LO = ((_this select 3) select 0) select 0;
 
-//classnames
+// classnames
 _wildcatArmed = "UK3CB_BAF_Wildcat_AH1_6_Generic_MTP";
 _chinook = "UK3CB_BAF_Chinook_HC2_MTP";
 _merlin = "UK3CB_BAF_Merlin_HC3_18_GPMG_MTP";
-_MQ9 = "UK3CB_BAF_MQ9_Reaper_Generic_MTP";
+// _MQ9 = "UK3CB_BAF_MQ9_Reaper_Generic_MTP";
 
 spawnAIR = {
 	params ["_location", "_aircraft"];

--- a/Scripts/VehicleSpawn/wheeled.sqf
+++ b/Scripts/VehicleSpawn/wheeled.sqf
@@ -1,6 +1,6 @@
 _LO = ((_this select 3) select 0) select 0;
 
-//classnames
+// classnames
 _coyoteGMG = "UK3CB_BAF_Coyote_Logistics_L134A1_W_MTP";
 _coyoteHMG = "UK3CB_BAF_Coyote_Logistics_L111A1_W_MTP";
 _jackal_GMG = "UK3CB_BAF_Jackal2_GMG_W_MTP";

--- a/init.sqf
+++ b/init.sqf
@@ -1,4 +1,4 @@
-//Vehicle Manager script inits
+// Vehicle Manager script inits
 call{
 	VM allowDamage false;
 	VM disableAI "MOVE";
@@ -7,7 +7,7 @@ call{
 	null = [] execVM "Scripts\VehicleSpawn\Menu\mainmenu.sqf";
 };
 
-//Quartermaster script inits
+// Quartermaster script inits
 call{
 	WM allowDamage false;
 	WM disableAI "MOVE";


### PR DESCRIPTION
I have removed the reaper drone and the challenge 2 till such a time as we need them however currently we do not. I have left the class names in the files and updated the comments across the files to match a more professional style.