### PR TITLE
updated gas mask in kits to reflect kat medical update

### DIFF
--- a/Scripts/Loadouts/QuarterMaster/Infantry.sqf
+++ b/Scripts/Loadouts/QuarterMaster/Infantry.sqf
@@ -67,7 +67,7 @@ _backpackMedic = "mpx_daysack7";
 _binoculars = "ACE_VectorDay";
 
 // gas mask
-_gasMask = "G_CBRN_M04_Hood";
+_gasMask = "kat_mask_M04";
 
 // Ctab tablet
 _cTab = "ItemcTab";


### PR DESCRIPTION
Due to a kat medical update gas masks now have timed properties on them and can wear down I have updated the mask to the take kat medical one for ease of config 